### PR TITLE
Make-it-work-again support for OFFLINE connection state.

### DIFF
--- a/SpotiFire.SpotifyLib/SpotifyTypes/Session.cs
+++ b/SpotiFire.SpotifyLib/SpotifyTypes/Session.cs
@@ -293,7 +293,7 @@ namespace SpotiFire.SpotifyLib
             if (s == null)
                 return;
 
-            if (s.ConnectionState == sp_connectionstate.LOGGED_IN && error == sp_error.OK)
+            if ((s.ConnectionState == sp_connectionstate.LOGGED_IN || s.ConnectionState == sp_connectionstate.OFFLINE) && error == sp_error.OK)
                 s.playlistContainer = SpotifyLib.PlaylistContainer.Get(s, libspotify.sp_session_playlistcontainer(sessionPtr));
 
             s.EnqueueEventWorkItem(new EventWorkItem(CreateDelegate<SessionEventArgs>(se => se.OnLoginComplete, s), new SessionEventArgs(error)));

--- a/SpotiFire.SpotifyLib/libspotify.cs
+++ b/SpotiFire.SpotifyLib/libspotify.cs
@@ -1539,7 +1539,8 @@ namespace SpotiFire.SpotifyLib
         LOGGED_OUT = 0,
         LOGGED_IN = 1,
         DISCONNECTED = 2,
-        UNDEFINED = 3
+        UNDEFINED = 3,
+        OFFLINE = 4
     }
 
     public enum sp_bitrate


### PR DESCRIPTION
Added OFFLINE connection state.
PlaylistContainer is now also retrieved when status is OFFLINE after login (because of new API).
