### PR TITLE
Added GetHashCode, Equals and equality operators

### DIFF
--- a/SpotiFire.LibSpotify/Album.cpp
+++ b/SpotiFire.LibSpotify/Album.cpp
@@ -83,21 +83,17 @@ AlbumBrowse ^Album::Browse() {
 }
 
 int Album::GetHashCode() {
-	SPLock lock;
 	return (new IntPtr(_ptr))->GetHashCode();
 }
 
 bool Album::Equals(Object^ other) {
-	SPLock lock;
 	return other != nullptr && GetType() == other->GetType() && GetHashCode() == other->GetHashCode();
 }
 
-bool SpotiFire::operator== (Album^ left, Album^ right) {
-	SPLock lock;
+bool Album::operator== (Album^ left, Album^ right) {
 	return Object::ReferenceEquals(left, right) || (!Object::ReferenceEquals(left, nullptr) && left->Equals(right));
 }
 
-bool SpotiFire::operator!= (Album^ left, Album^ right) {
-	SPLock lock;
+bool Album::operator!= (Album^ left, Album^ right) {
 	return !(left == right);
 }

--- a/SpotiFire.LibSpotify/Album.h
+++ b/SpotiFire.LibSpotify/Album.h
@@ -122,29 +122,29 @@ namespace SpotiFire {
 		/// <returns>	true if the given object is equal to the album, otherwise false. </returns>
 		///-------------------------------------------------------------------------------------------------
 		virtual bool Equals(Object^ other) override;
+
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given albums should be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The album on the left-hand side of the operator. </param>
+		/// <param name="right">	The album on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given albums are equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator== (Album^ left, Album^ right);
+
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given albums should not be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The album on the left-hand side of the operator. </param>
+		/// <param name="right">	The album on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given albums are not equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator!= (Album^ left, Album^ right);
 	};
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given albums should be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The album on the left-hand side of the operator. </param>
-	/// <param name="right">	The album on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given albums are equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator== (Album^ left, Album^ right);
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given albums should not be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The album on the left-hand side of the operator. </param>
-	/// <param name="right">	The album on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given albums are not equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator!= (Album^ left, Album^ right);
 }

--- a/SpotiFire.LibSpotify/Albumbrowse.cpp
+++ b/SpotiFire.LibSpotify/Albumbrowse.cpp
@@ -154,21 +154,17 @@ bool AlbumBrowse::AddContinuation(Action ^continuationAction) {
 }
 
 int AlbumBrowse::GetHashCode() {
-	SPLock lock;
 	return (new IntPtr(_ptr))->GetHashCode();
 }
 
 bool AlbumBrowse::Equals(Object^ other) {
-	SPLock lock;
 	return other != nullptr && GetType() == other->GetType() && GetHashCode() == other->GetHashCode();
 }
 
-bool SpotiFire::operator== (AlbumBrowse^ left, AlbumBrowse^ right) {
-	SPLock lock;
+bool AlbumBrowse::operator== (AlbumBrowse^ left, AlbumBrowse^ right) {
 	return Object::ReferenceEquals(left, right) || (!Object::ReferenceEquals(left, nullptr) && left->Equals(right));
 }
 
-bool SpotiFire::operator!= (AlbumBrowse^ left, AlbumBrowse^ right) {
-	SPLock lock;
+bool AlbumBrowse::operator!= (AlbumBrowse^ left, AlbumBrowse^ right) {
 	return !(left == right);
 }

--- a/SpotiFire.LibSpotify/Albumbrowse.h
+++ b/SpotiFire.LibSpotify/Albumbrowse.h
@@ -126,6 +126,30 @@ namespace SpotiFire {
 		///-------------------------------------------------------------------------------------------------
 		virtual bool Equals(Object^ other) override;
 
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given albumbrowse objects should be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The albumbrowse object on the left-hand side of the operator. </param>
+		/// <param name="right">	The albumbrowse object on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given albumbrowse objects are equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator== (AlbumBrowse^ left, AlbumBrowse^ right);
+
+		///-----------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given albumbrowse objects should not be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The albumbrowse object on the left-hand side of the operator. </param>
+		/// <param name="right">	The albumbrowse object on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given albumbrowse objects are not equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator!= (AlbumBrowse^ left, AlbumBrowse^ right);
+
 	private:
 		virtual property bool IsComplete { bool get() sealed = ISpotifyAwaitable::IsComplete::get; }
 		virtual bool AddContinuation(Action ^continuationAction) sealed = ISpotifyAwaitable::AddContinuation;
@@ -136,28 +160,4 @@ namespace SpotiFire {
 		// Events
 		void complete();
 	};
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given albumbrowse objects should be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The albumbrowse object on the left-hand side of the operator. </param>
-	/// <param name="right">	The albumbrowse object on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given albumbrowse objects are equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator== (AlbumBrowse^ left, AlbumBrowse^ right);
-
-	///-----------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given albumbrowse objects should not be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The albumbrowse object on the left-hand side of the operator. </param>
-	/// <param name="right">	The albumbrowse object on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given albumbrowse objects are not equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator!= (AlbumBrowse^ left, AlbumBrowse^ right);
 }

--- a/SpotiFire.LibSpotify/Artist.cpp
+++ b/SpotiFire.LibSpotify/Artist.cpp
@@ -45,21 +45,17 @@ ArtistBrowse ^Artist::Browse(ArtistBrowseType type) {
 }
 
 int Artist::GetHashCode() {
-	SPLock lock;
 	return (new IntPtr(_ptr))->GetHashCode();
 }
 
 bool Artist::Equals(Object^ other) {
-	SPLock lock;
 	return other != nullptr && GetType() == other->GetType() && GetHashCode() == other->GetHashCode();
 }
 
-bool SpotiFire::operator== (Artist^ left, Artist^ right) {
-	SPLock lock;
+bool Artist::operator== (Artist^ left, Artist^ right) {
 	return Object::ReferenceEquals(left, right) || (!Object::ReferenceEquals(left, nullptr) && left->Equals(right));
 }
 
-bool SpotiFire::operator!= (Artist^ left, Artist^ right) {
-	SPLock lock;
+bool Artist::operator!= (Artist^ left, Artist^ right) {
 	return !(left == right);
 }

--- a/SpotiFire.LibSpotify/Artist.h
+++ b/SpotiFire.LibSpotify/Artist.h
@@ -85,29 +85,29 @@ namespace SpotiFire {
 		/// <returns>	true if the given object is equal to the artist, otherwise false. </returns>
 		///-------------------------------------------------------------------------------------------------
 		virtual bool Equals(Object^ other) override;
-	};
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given artists should be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The artist on the left-hand side of the operator. </param>
-	/// <param name="right">	The artist on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given artists are equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator== (Artist^ left, Artist^ right);
 
 		///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given artists should not be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The artist on the left-hand side of the operator. </param>
-	/// <param name="right">	The artist on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given artists are not equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator!= (Artist^ left, Artist^ right);
+		/// <summary>	Checks if the given artists should be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The artist on the left-hand side of the operator. </param>
+		/// <param name="right">	The artist on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given artists are equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator== (Artist^ left, Artist^ right);
+
+			///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given artists should not be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The artist on the left-hand side of the operator. </param>
+		/// <param name="right">	The artist on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given artists are not equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator!= (Artist^ left, Artist^ right);
+	};
 }

--- a/SpotiFire.LibSpotify/Artistbrowse.cpp
+++ b/SpotiFire.LibSpotify/Artistbrowse.cpp
@@ -110,21 +110,17 @@ bool ArtistBrowse::AddContinuation(Action ^continuationAction) {
 }
 
 int ArtistBrowse::GetHashCode() {
-	SPLock lock;
 	return (new IntPtr(_ptr))->GetHashCode();
 }
 
 bool ArtistBrowse::Equals(Object^ other) {
-	SPLock lock;
 	return other != nullptr && GetType() == other->GetType() && GetHashCode() == other->GetHashCode();
 }
 
-bool SpotiFire::operator== (ArtistBrowse^ left, ArtistBrowse^ right) {
-	SPLock lock;
+bool ArtistBrowse::operator== (ArtistBrowse^ left, ArtistBrowse^ right) {
 	return Object::ReferenceEquals(left, right) || (!Object::ReferenceEquals(left, nullptr) && left->Equals(right));
 }
 
-bool SpotiFire::operator!= (ArtistBrowse^ left, ArtistBrowse^ right) {
-	SPLock lock;
+bool ArtistBrowse::operator!= (ArtistBrowse^ left, ArtistBrowse^ right) {
 	return !(left == right);
 }

--- a/SpotiFire.LibSpotify/Artistbrowse.h
+++ b/SpotiFire.LibSpotify/Artistbrowse.h
@@ -122,6 +122,30 @@ namespace SpotiFire {
 		///-------------------------------------------------------------------------------------------------
 		virtual bool Equals(Object^ other) override;
 
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given artistbrowse objects should be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The artistbrowse object on the left-hand side of the operator. </param>
+		/// <param name="right">	The artistbrowse object on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given artistbrowse objects are equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator== (ArtistBrowse^ left, ArtistBrowse^ right);
+
+		///-----------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given artistbrowse objects should not be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The artistbrowse object on the left-hand side of the operator. </param>
+		/// <param name="right">	The artistbrowse object on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given artistbrowse objects are not equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator!= (ArtistBrowse^ left, ArtistBrowse^ right);
+
 	private:
 		virtual property bool IsComplete { bool get() sealed = ISpotifyAwaitable::IsComplete::get; }
 		virtual bool AddContinuation(Action ^continuationAction) sealed = ISpotifyAwaitable::AddContinuation;
@@ -132,28 +156,4 @@ namespace SpotiFire {
 		// Events
 		void complete();
 	};
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given artistbrowse objects should be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The artistbrowse object on the left-hand side of the operator. </param>
-	/// <param name="right">	The artistbrowse object on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given artistbrowse objects are equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator== (ArtistBrowse^ left, ArtistBrowse^ right);
-
-	///-----------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given artistbrowse objects should not be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The artistbrowse object on the left-hand side of the operator. </param>
-	/// <param name="right">	The artistbrowse object on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given artistbrowse objects are not equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator!= (ArtistBrowse^ left, ArtistBrowse^ right);
 }

--- a/SpotiFire.LibSpotify/Image.cpp
+++ b/SpotiFire.LibSpotify/Image.cpp
@@ -140,21 +140,17 @@ bool Image::AddContinuation(Action ^continuationAction) {
 }
 
 int Image::GetHashCode() {
-	SPLock lock;
 	return (new IntPtr(_ptr))->GetHashCode();
 }
 
 bool Image::Equals(Object^ other) {
-	SPLock lock;
 	return other != nullptr && GetType() == other->GetType() && GetHashCode() == other->GetHashCode();
 }
 
-bool SpotiFire::operator== (Image^ left, Image^ right) {
-	SPLock lock;
+bool Image::operator== (Image^ left, Image^ right) {
 	return Object::ReferenceEquals(left, right) || (!Object::ReferenceEquals(left, nullptr) && left->Equals(right));
 }
 
-bool SpotiFire::operator!= (Image^ left, Image^ right) {
-	SPLock lock;
+bool Image::operator!= (Image^ left, Image^ right) {
 	return !(left == right);
 }

--- a/SpotiFire.LibSpotify/Image.h
+++ b/SpotiFire.LibSpotify/Image.h
@@ -113,6 +113,30 @@ namespace SpotiFire {
 		///-------------------------------------------------------------------------------------------------
 		virtual bool Equals(Object^ other) override;
 
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given images should be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The image on the left-hand side of the operator. </param>
+		/// <param name="right">	The image on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given images are equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator== (Image^ left, Image^ right);
+
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given images should not be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The image on the left-hand side of the operator. </param>
+		/// <param name="right">	The image on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given images are not equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator!= (Image^ left, Image^ right);
+
 	private:
 		virtual property bool IsComplete { bool get() sealed = ISpotifyAwaitable::IsComplete::get; }
 		virtual bool AddContinuation(Action ^continuationAction) sealed = ISpotifyAwaitable::AddContinuation;
@@ -121,28 +145,4 @@ namespace SpotiFire {
 		// Spotify events
 		void complete();
 	};
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given images should be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The image on the left-hand side of the operator. </param>
-	/// <param name="right">	The image on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given images are equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator== (Image^ left, Image^ right);
-
-		///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given images should not be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The image on the left-hand side of the operator. </param>
-	/// <param name="right">	The image on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given images are not equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator!= (Image^ left, Image^ right);
 }

--- a/SpotiFire.LibSpotify/Inbox.cpp
+++ b/SpotiFire.LibSpotify/Inbox.cpp
@@ -80,21 +80,17 @@ Task ^Inbox::PostTracks(SpotiFire::Session ^session, String ^user, array<Track ^
 }
 
 int Inbox::GetHashCode() {
-	SPLock lock;
 	return (new IntPtr(_ptr))->GetHashCode();
 }
 
 bool Inbox::Equals(Object^ other) {
-	SPLock lock;
 	return other != nullptr && GetType() == other->GetType() && GetHashCode() == other->GetHashCode();
 }
 
-bool SpotiFire::operator== (Inbox^ left, Inbox^ right) {
-	SPLock lock;
+bool Inbox::operator== (Inbox^ left, Inbox^ right) {
 	return Object::ReferenceEquals(left, right) || (!Object::ReferenceEquals(left, nullptr) && left->Equals(right));
 }
 
-bool SpotiFire::operator!= (Inbox^ left, Inbox^ right) {
-	SPLock lock;
+bool Inbox::operator!= (Inbox^ left, Inbox^ right) {
 	return !(left == right);
 }

--- a/SpotiFire.LibSpotify/Inbox.h
+++ b/SpotiFire.LibSpotify/Inbox.h
@@ -76,29 +76,29 @@ namespace SpotiFire {
 		/// <returns>	true if the given object is equal to the inbox, otherwise false. </returns>
 		///-------------------------------------------------------------------------------------------------
 		virtual bool Equals(Object^ other) override;
+
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given inboxes should be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The inbox on the left-hand side of the operator. </param>
+		/// <param name="right">	The inbox on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given inboxes are equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator== (Inbox^ left, Inbox^ right);
+
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given albums should not be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The inbox on the left-hand side of the operator. </param>
+		/// <param name="right">	The inbox on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given inboxes are not equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator!= (Inbox^ left, Inbox^ right);
 	};
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given inboxes should be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The inbox on the left-hand side of the operator. </param>
-	/// <param name="right">	The inbox on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given inboxes are equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator== (Inbox^ left, Inbox^ right);
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given albums should not be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The inbox on the left-hand side of the operator. </param>
-	/// <param name="right">	The inbox on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given inboxes are not equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator!= (Inbox^ left, Inbox^ right);
 }

--- a/SpotiFire.LibSpotify/Link.cpp
+++ b/SpotiFire.LibSpotify/Link.cpp
@@ -145,21 +145,17 @@ Link ^Link::CreatePortrait(ArtistBrowse ^artistBrowse, int index) {
 }
 
 int Link::GetHashCode() {
-	SPLock lock;
 	return (new IntPtr(_ptr))->GetHashCode();
 }
 
 bool Link::Equals(Object^ other) {
-	SPLock lock;
 	return other != nullptr && GetType() == other->GetType() && GetHashCode() == other->GetHashCode();
 }
 
-bool SpotiFire::operator== (Link^ left, Link^ right) {
-	SPLock lock;
+bool Link::operator== (Link^ left, Link^ right) {
 	return Object::ReferenceEquals(left, right) || (!Object::ReferenceEquals(left, nullptr) && left->Equals(right));
 }
 
-bool SpotiFire::operator!= (Link^ left, Link^ right) {
-	SPLock lock;
+bool Link::operator!= (Link^ left, Link^ right) {
 	return !(left == right);
 }

--- a/SpotiFire.LibSpotify/Link.h
+++ b/SpotiFire.LibSpotify/Link.h
@@ -121,6 +121,30 @@ namespace SpotiFire {
 		///-------------------------------------------------------------------------------------------------
 		virtual bool Equals(Object^ other) override;
 
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given links should be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The link on the left-hand side of the operator. </param>
+		/// <param name="right">	The link on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given links are equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator== (Link^ left, Link^ right);
+
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given links should not be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The link on the left-hand side of the operator. </param>
+		/// <param name="right">	The link on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given links are not equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator!= (Link^ left, Link^ right);
+
 	internal:
 		static Link ^Create(SpotiFire::Session ^session, String ^link);
 		static Link ^Create(Track ^track, TimeSpan offset);
@@ -135,28 +159,4 @@ namespace SpotiFire {
 		static Link ^CreatePortrait(Artist ^artist, ImageSize size);
 		static Link ^CreatePortrait(ArtistBrowse ^artistBrowse, int index);
 	};
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given links should be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The link on the left-hand side of the operator. </param>
-	/// <param name="right">	The link on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given links are equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator== (Link^ left, Link^ right);
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given links should not be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The link on the left-hand side of the operator. </param>
-	/// <param name="right">	The link on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given links are not equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator!= (Link^ left, Link^ right);
 }

--- a/SpotiFire.LibSpotify/Playlist.cpp
+++ b/SpotiFire.LibSpotify/Playlist.cpp
@@ -150,22 +150,18 @@ bool Playlist::IsReady::get() {
 }
 
 int Playlist::GetHashCode() {
-	SPLock lock;
 	return (new IntPtr(_ptr))->GetHashCode();
 }
 
 bool Playlist::Equals(Object^ other) {
-	SPLock lock;
 	return other != nullptr && GetType() == other->GetType() && GetHashCode() == other->GetHashCode();
 }
 
-bool SpotiFire::operator== (Playlist^ left, Playlist^ right) {
-	SPLock lock;
+bool Playlist::operator== (Playlist^ left, Playlist^ right) {
 	return Object::ReferenceEquals(left, right) || (!Object::ReferenceEquals(left, nullptr) && left->Equals(right));
 }
 
-bool SpotiFire::operator!= (Playlist^ left, Playlist^ right) {
-	SPLock lock;
+bool Playlist::operator!= (Playlist^ left, Playlist^ right) {
 	return !(left == right);
 }
 

--- a/SpotiFire.LibSpotify/Playlist.h
+++ b/SpotiFire.LibSpotify/Playlist.h
@@ -140,6 +140,30 @@ namespace SpotiFire {
 		/// <returns>	true if the given object is equal to the playlist, otherwise false. </returns>
 		///-------------------------------------------------------------------------------------------------
 		virtual bool Equals(Object^ other) override;
+		
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given playlists should be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The playlist on the left-hand side of the operator. </param>
+		/// <param name="right">	The playlist on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given playlists are equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator== (Playlist^ left, Playlist^ right);
+
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given playlists should not be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The playlist on the left-hand side of the operator. </param>
+		/// <param name="right">	The playlist on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given playlists are not equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator!= (Playlist^ left, Playlist^ right);
 
 		// TODO: Add subscribing users
 
@@ -150,28 +174,4 @@ namespace SpotiFire {
 		virtual Error SetTrackSeen(int trackIndex, bool value) sealed;
 		virtual String ^GetTrackMessage(int trackIndex) sealed;
 	};
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given playlists should be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The playlist on the left-hand side of the operator. </param>
-	/// <param name="right">	The playlist on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given playlists are equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator== (const Playlist^ left, const Playlist^ right);
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given playlists should not be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The playlist on the left-hand side of the operator. </param>
-	/// <param name="right">	The playlist on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given playlists are not equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator!= (Playlist^ left, Playlist^ right);
 }

--- a/SpotiFire.LibSpotify/Playlistcontainer.cpp
+++ b/SpotiFire.LibSpotify/Playlistcontainer.cpp
@@ -159,21 +159,17 @@ bool PlaylistContainer::AddContinuation(Action ^continuationAction) {
 }
 
 int PlaylistContainer::GetHashCode() {
-	SPLock lock;
 	return (new IntPtr(_ptr))->GetHashCode();
 }
 
 bool PlaylistContainer::Equals(Object^ other) {
-	SPLock lock;
 	return other != nullptr && GetType() == other->GetType() && GetHashCode() == other->GetHashCode();
 }
 
-bool SpotiFire::operator== (PlaylistContainer^ left, PlaylistContainer^ right) {
-	SPLock lock;
+bool PlaylistContainer::operator== (PlaylistContainer^ left, PlaylistContainer^ right) {
 	return Object::ReferenceEquals(left, right) || (!Object::ReferenceEquals(left, nullptr) && left->Equals(right));
 }
 
-bool SpotiFire::operator!= (PlaylistContainer^ left, PlaylistContainer^ right) {
-	SPLock lock;
+bool PlaylistContainer::operator!= (PlaylistContainer^ left, PlaylistContainer^ right) {
 	return !(left == right);
 }

--- a/SpotiFire.LibSpotify/Playlistcontainer.h
+++ b/SpotiFire.LibSpotify/Playlistcontainer.h
@@ -96,6 +96,30 @@ namespace SpotiFire {
 		///-------------------------------------------------------------------------------------------------
 		virtual bool Equals(Object^ other) override;
 
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given playlistcontainers should be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The playlistcontainer on the left-hand side of the operator. </param>
+		/// <param name="right">	The playlistcontainer on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given playlistcontainers are equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator== (PlaylistContainer^ left, PlaylistContainer^ right);
+
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given playlistcontainers should not be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The playlistcontainer on the left-hand side of the operator. </param>
+		/// <param name="right">	The playlistcontainer on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given playlistcontainers are not equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator!= (PlaylistContainer^ left, PlaylistContainer^ right);
+
 	internal:
 		virtual Error AddFolder(int index, String ^name) sealed;
 		virtual PlaylistType GetPlaylistType(int index) sealed;
@@ -110,28 +134,4 @@ namespace SpotiFire {
 		// Events
 		void complete();
 	};
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given playlistcontainers should be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The playlistcontainer on the left-hand side of the operator. </param>
-	/// <param name="right">	The playlistcontainer on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given playlistcontainers are equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator== (PlaylistContainer^ left, PlaylistContainer^ right);
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given playlistcontainers should not be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The playlistcontainer on the left-hand side of the operator. </param>
-	/// <param name="right">	The playlistcontainer on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given playlistcontainers are not equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator!= (PlaylistContainer^ left, PlaylistContainer^ right);
 }

--- a/SpotiFire.LibSpotify/Search.cpp
+++ b/SpotiFire.LibSpotify/Search.cpp
@@ -240,21 +240,17 @@ bool Search::AddContinuation(Action ^continuationAction) {
 }
 
 int Search::GetHashCode() {
-	SPLock lock;
 	return (new IntPtr(_ptr))->GetHashCode();
 }
 
 bool Search::Equals(Object^ other) {
-	SPLock lock;
 	return other != nullptr && GetType() == other->GetType() && GetHashCode() == other->GetHashCode();
 }
 
-bool SpotiFire::operator== (Search^ left, Search^ right) {
-	SPLock lock;
+bool Search::operator== (Search^ left, Search^ right) {
 	return Object::ReferenceEquals(left, right) || (!Object::ReferenceEquals(left, nullptr) && left->Equals(right));
 }
 
-bool SpotiFire::operator!= (Search^ left, Search^ right) {
-	SPLock lock;
+bool Search::operator!= (Search^ left, Search^ right) {
 	return !(left == right);
 }

--- a/SpotiFire.LibSpotify/Search.h
+++ b/SpotiFire.LibSpotify/Search.h
@@ -147,6 +147,30 @@ namespace SpotiFire {
 		///-------------------------------------------------------------------------------------------------
 		virtual bool Equals(Object^ other) override;
 
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given search objects should be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The search object on the left-hand side of the operator. </param>
+		/// <param name="right">	The search object on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given searches are equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator== (Search^ left, Search^ right);
+
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given search objects should not be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The search object on the left-hand side of the operator. </param>
+		/// <param name="right">	The search object on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given search objects are not equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator!= (Search^ left, Search^ right);
+
 	private:
 		virtual property bool IsComplete { bool get() sealed = ISpotifyAwaitable::IsComplete::get; }
 		virtual bool AddContinuation(Action ^continuationAction) sealed = ISpotifyAwaitable::AddContinuation;
@@ -157,28 +181,4 @@ namespace SpotiFire {
 		// Spotify events
 		void complete();
 	};
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given search objects should be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The search object on the left-hand side of the operator. </param>
-	/// <param name="right">	The search object on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given searches are equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator== (Search^ left, Search^ right);
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given search objects should not be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The search object on the left-hand side of the operator. </param>
-	/// <param name="right">	The search object on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given search objects are not equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator!= (Search^ left, Search^ right);
 }

--- a/SpotiFire.LibSpotify/Session.cpp
+++ b/SpotiFire.LibSpotify/Session.cpp
@@ -465,22 +465,18 @@ void Session::ConnectionRules::set(SpotiFire::ConnectionRules rules) {
 }
 
 int Session::GetHashCode() {
-	SPLock lock;
 	return (new IntPtr(_ptr))->GetHashCode();
 }
 
 bool Session::Equals(Object^ other) {
-	SPLock lock;
 	return other != nullptr && GetType() == other->GetType() && GetHashCode() == other->GetHashCode();
 }
 
-bool SpotiFire::operator== (Session^ left, Session^ right) {
-	SPLock lock;
+bool Session::operator== (Session^ left, Session^ right) {
 	return Object::ReferenceEquals(left, right) || (!Object::ReferenceEquals(left, nullptr) && left->Equals(right));
 }
 
-bool SpotiFire::operator!= (Session^ left, Session^ right) {
-	SPLock lock;
+bool Session::operator!= (Session^ left, Session^ right) {
 	return !(left == right);
 }
 

--- a/SpotiFire.LibSpotify/Session.h
+++ b/SpotiFire.LibSpotify/Session.h
@@ -342,6 +342,30 @@ namespace SpotiFire {
 		virtual bool Equals(Object^ other) override;
 
 		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given sessions should be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The session on the left-hand side of the operator. </param>
+		/// <param name="right">	The session on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given sessions are equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator== (Session^ left, Session^ right);
+
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given sessions should not be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The session on the left-hand side of the operator. </param>
+		/// <param name="right">	The session on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given sessions are not equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator!= (Session^ left, Session^ right);
+
+		///-------------------------------------------------------------------------------------------------
 		/// <summary>	Event queue for all listeners interested in MetadataUpdated events. </summary>
 		///
 		/// <remarks>	The MetadataUpdated event provides a way for applications to be notified whenever
@@ -534,28 +558,4 @@ namespace SpotiFire {
 		///-------------------------------------------------------------------------------------------------
 		event PrivateSessionModeEventHandler ^PrivateSessionModeChanged;
 	};
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given sessions should be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The session on the left-hand side of the operator. </param>
-	/// <param name="right">	The session on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given sessions are equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator== (Session^ left, Session^ right);
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given sessions should not be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The session on the left-hand side of the operator. </param>
-	/// <param name="right">	The session on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given sessions are not equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator!= (Session^ left, Session^ right);
 }

--- a/SpotiFire.LibSpotify/Toplist.cpp
+++ b/SpotiFire.LibSpotify/Toplist.cpp
@@ -158,21 +158,17 @@ Task<ToplistBrowse ^> ^ToplistBrowse::CreateToplistBrowse(SpotiFire::Session ^se
 }
 
 int ToplistBrowse::GetHashCode() {
-	SPLock lock;
 	return (new IntPtr(_ptr))->GetHashCode();
 }
 
 bool ToplistBrowse::Equals(Object^ other) {
-	SPLock lock;
 	return other != nullptr && GetType() == other->GetType() && GetHashCode() == other->GetHashCode();
 }
 
-bool SpotiFire::operator== (ToplistBrowse^ left, ToplistBrowse^ right) {
-	SPLock lock;
+bool ToplistBrowse::operator== (ToplistBrowse^ left, ToplistBrowse^ right) {
 	return Object::ReferenceEquals(left, right) || (!Object::ReferenceEquals(left, nullptr) && left->Equals(right));
 }
 
-bool SpotiFire::operator!= (ToplistBrowse^ left, ToplistBrowse^ right) {
-	SPLock lock;
+bool ToplistBrowse::operator!= (ToplistBrowse^ left, ToplistBrowse^ right) {
 	return !(left == right);
 }

--- a/SpotiFire.LibSpotify/Toplist.h
+++ b/SpotiFire.LibSpotify/Toplist.h
@@ -98,6 +98,32 @@ namespace SpotiFire {
 		virtual bool Equals(Object^ other) override;
 
 		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given toplistbrowse objects should be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The toplistbrowse object on the left-hand side of the operator. </param>
+		/// <param name="right">	The toplistbrowse object on the right-hand side of the operator.
+		///				</param>
+		///
+		/// <returns>	true if the given toplistbrowse objects are equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator== (ToplistBrowse^ left, ToplistBrowse^ right);
+
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given toplistbrowse objects should not be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The toplistbrowse object on the left-hand side of the operator. </param>
+		/// <param name="right">	The toplistbrowse object on the right-hand side of the operator.
+		///				</param>
+		///
+		/// <returns>	true if the given toplistbrowse objects are not equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator!= (ToplistBrowse^ left, ToplistBrowse^ right);
+
+		///-------------------------------------------------------------------------------------------------
 		/// <summary>	Initiate a request for browsing an toplist. </summary>
 		///
 		/// <remarks>	Aleksander, 09.05.2013. </remarks>
@@ -112,30 +138,4 @@ namespace SpotiFire {
 		[System::Runtime::CompilerServices::ExtensionAttribute]
 		static Task<ToplistBrowse ^> ^CreateToplistBrowse(SpotiFire::Session ^session, ToplistType type, ToplistRegion region, String ^username);
 	};
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given toplistbrowse objects should be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The toplistbrowse object on the left-hand side of the operator. </param>
-	/// <param name="right">	The toplistbrowse object on the right-hand side of the operator.
-	///				</param>
-	///
-	/// <returns>	true if the given toplistbrowse objects are equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator== (ToplistBrowse^ left, ToplistBrowse^ right);
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given toplistbrowse objects should not be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The toplistbrowse object on the left-hand side of the operator. </param>
-	/// <param name="right">	The toplistbrowse object on the right-hand side of the operator.
-	///				</param>
-	///
-	/// <returns>	true if the given toplistbrowse objects are not equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator!= (ToplistBrowse^ left, ToplistBrowse^ right);
 }

--- a/SpotiFire.LibSpotify/Track.cpp
+++ b/SpotiFire.LibSpotify/Track.cpp
@@ -123,21 +123,17 @@ String ^Track::Name::get() {
 }
 
 int Track::GetHashCode() {
-	SPLock lock;
 	return (new IntPtr(_ptr))->GetHashCode();
 }
 
 bool Track::Equals(Object^ other) {
-	SPLock lock;
 	return other != nullptr && GetType() == other->GetType() && GetHashCode() == other->GetHashCode();
 }
 
-bool SpotiFire::operator== (Track^ left, Track^ right) {
-	SPLock lock;
+bool Track::operator== (Track^ left, Track^ right) {
 	return Object::ReferenceEquals(left, right) || (!Object::ReferenceEquals(left, nullptr) && left->Equals(right));
 }
 
-bool SpotiFire::operator!= (Track^ left, Track^ right) {
-	SPLock lock;
+bool Track::operator!= (Track^ left, Track^ right) {
 	return !(left == right);
 }

--- a/SpotiFire.LibSpotify/Track.h
+++ b/SpotiFire.LibSpotify/Track.h
@@ -168,29 +168,29 @@ namespace SpotiFire {
 		/// <returns>	true if the given object is equal to the track, otherwise false. </returns>
 		///-------------------------------------------------------------------------------------------------
 		virtual bool Equals(Object^ other) override;
+
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given tracks should be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The track on the left-hand side of the operator. </param>
+		/// <param name="right">	The track on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given tracks are equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator== (Track^ left, Track^ right);
+
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given tracks should not be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The track on the left-hand side of the operator. </param>
+		/// <param name="right">	The track on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given tracks are not equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator!= (Track^ left, Track^ right);
 	};
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given tracks should be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The track on the left-hand side of the operator. </param>
-	/// <param name="right">	The track on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given tracks are equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator== (Track^ left, Track^ right);
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given tracks should not be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The track on the left-hand side of the operator. </param>
-	/// <param name="right">	The track on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given tracks are not equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator!= (Track^ left, Track^ right);
 }

--- a/SpotiFire.LibSpotify/User.cpp
+++ b/SpotiFire.LibSpotify/User.cpp
@@ -41,21 +41,17 @@ String ^User::DisplayName::get() {
 }
 
 int User::GetHashCode() {
-	SPLock lock;
 	return (new IntPtr(_ptr))->GetHashCode();
 }
 
 bool User::Equals(Object^ other) {
-	SPLock lock;
 	return other != nullptr && GetType() == other->GetType() && GetHashCode() == other->GetHashCode();
 }
 
-bool SpotiFire::operator== (User^ left, User^ right) {
-	SPLock lock;
+bool User::operator== (User^ left, User^ right) {
 	return Object::ReferenceEquals(left, right) || (!Object::ReferenceEquals(left, nullptr) && left->Equals(right));
 }
 
-bool SpotiFire::operator!= (User^ left, User^ right) {
-	SPLock lock;
+bool User::operator!= (User^ left, User^ right) {
 	return !(left == right);
 }

--- a/SpotiFire.LibSpotify/User.h
+++ b/SpotiFire.LibSpotify/User.h
@@ -79,29 +79,29 @@ namespace SpotiFire {
 		/// <returns>	true if the given object is equal to the user, otherwise false. </returns>
 		///-------------------------------------------------------------------------------------------------
 		virtual bool Equals(Object^ other) override;
+
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given users should be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The user on the left-hand side of the operator. </param>
+		/// <param name="right">	The user on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given users are equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator== (User^ left, User^ right);
+
+		///-------------------------------------------------------------------------------------------------
+		/// <summary>	Checks if the given users should not be considered equal. </summary>
+		///
+		/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
+		///
+		/// <param name="left">	The user on the left-hand side of the operator. </param>
+		/// <param name="right">	The user on the right-hand side of the operator. </param>
+		///
+		/// <returns>	true if the given users are not equal, otherwise false. </returns>
+		///-------------------------------------------------------------------------------------------------
+		static bool operator!= (User^ left, User^ right);
 	};
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given users should be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The user on the left-hand side of the operator. </param>
-	/// <param name="right">	The user on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given users are equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator== (User^ left, User^ right);
-
-	///-------------------------------------------------------------------------------------------------
-	/// <summary>	Checks if the given users should not be considered equal. </summary>
-	///
-	/// <remarks>	Chris Brandhorst, 16.05.2013. </remarks>
-	///
-	/// <param name="left">	The user on the left-hand side of the operator. </param>
-	/// <param name="right">	The user on the right-hand side of the operator. </param>
-	///
-	/// <returns>	true if the given users are not equal, otherwise false. </returns>
-	///-------------------------------------------------------------------------------------------------
-	bool operator!= (User^ left, User^ right);
 }


### PR DESCRIPTION
Operators are declared as static, so they are not overridden by C#.
Additions are available for alle Spotify types.

Resolves #30 
