### PR TITLE
Fixed a bug in awaiting a track from a link.

### DIFF
--- a/SpotiFire.TestClient/Program.cs
+++ b/SpotiFire.TestClient/Program.cs
@@ -107,7 +107,10 @@ namespace SpotiFire.TestClient
             await session.Login(Console.ReadLine(), Console.ReadLine(), false);
             session.PreferredBitrate = BitRate.Bitrate320k;
 
-            await TestAwaitLink("spotify:track:0yA1MBQ60SoiYt7xqdS3H1", session);
+            TestAwaitLink("spotify:track:0yA1MBQ60SoiYt7xqdS3H1", session);
+            TestAwaitLink("spotify:track:3lcP1anKWxdp6IRNF9vGhu", session);
+            TestAwaitLink("spotify:track:0cthN0HhrEtp1gIUPhNv2W", session); 
+            TestAwaitLink("spotify:track:2hlYLICCS20aLk9IfBqMCE", session);
 
             await session.PlaylistContainer;
             while (session.PlaylistContainer.Playlists.Count < 1)

--- a/SpotiFire.TestClient/Program.cs
+++ b/SpotiFire.TestClient/Program.cs
@@ -107,6 +107,8 @@ namespace SpotiFire.TestClient
             await session.Login(Console.ReadLine(), Console.ReadLine(), false);
             session.PreferredBitrate = BitRate.Bitrate320k;
 
+            await TestAwaitLink("spotify:track:0yA1MBQ60SoiYt7xqdS3H1", session);
+
             await session.PlaylistContainer;
             while (session.PlaylistContainer.Playlists.Count < 1)
             {
@@ -165,6 +167,14 @@ namespace SpotiFire.TestClient
                 Console.WriteLine("No matching tracks.");
             }
             await session.Logout();
+        }
+
+        private static async Task TestAwaitLink(string trackUri, Session session)
+        {
+            var link = session.ParseLink(trackUri);
+            Console.WriteLine("Awaiting the Link as a Track. Should write Track title next.");
+            var track = await link.AsTrack();
+            Console.WriteLine("Successfully awaited Track with title {0}.", track.Name);
         }
 
         static async Task PlayPlaylistForever(Session session, Playlist starred)


### PR DESCRIPTION
 (possibly awaiting other things from links too. not tested these though)
Added a "Test" to the Console TestClient

Set the timerinterval to 20ms but introduced timer management (it's not actually running if there are no awaited items)

Timer tick callback is iterating over a copy of the static field awaited items to prevent removing an item from the collection that's currently iterated over

